### PR TITLE
Update to provide spancontext instead of span to integrate better with other opentracing libraries, remove TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,22 @@ dependencies {
 ## Usage
 
 - Intialize an OpenTracing tracer
-- Create an `ActiveSpanSource` to return a parent span when a span is created for a request.
+- Create an `ActiveSpanContextSource` to return a parent spancontext when a span is created for a request.
 - Create a `SpanDecorator` or use the `DEFAULT` implementation.
 - Create a `TracingAsyncHttpClient` and use it to make requests.
 
 ```java
 class MyClass {
-    final ThreadLocal<Span> activeSpan;
+    final ThreadLocal<SpanContext> activeSpanContext;
 
     public MyClass() {
-        activeSpan = new ThreadLocal<Span>() {};
+        activeSpan = new ThreadLocal<SpanContext>();
 
         // Source that can extract span data and keep it in a thread-local:
-        TracingAsyncHttpClient.ActiveSpanSource activeSpanSource = 
-            new TracingAsyncHttpClient.ActiveSpanSource() {
-                public Span getActiveSpan() {
-                    return activeSpan.get();
+        TracingAsyncHttpClient.ActiveSpanContextSource spanContextSource = 
+            new TracingAsyncHttpClient.ActiveSpanContextSource() {
+                public Span getActiveSpanContext() {
+                    return activeSpanContext.get();
                 }
             };
 
@@ -53,7 +53,7 @@ class MyClass {
 
         AsyncHttpClient client = new TracingAsyncHttpClient(
                     tracer,
-                    activeSpanSource,
+                    spanContextSource,
                     SpanDecorator.DEFAULT
                 );
     }


### PR DESCRIPTION
I've recently did an implementation of opentracing on a project that used both the vertx.io opentracing library and this library, and needed to make this change.
This ultimately is less burden/looser requirement to only need a SpanContext rather than span, since in actuality the library was only using the SpanContext.

https://github.com/opentracing-contrib/java-asynchttpclient/blob/7d5b9804afac752387dbdcde1db511191bf39b4f/src/main/java/io/opentracing/contrib/asynchttpclient/TracingAsyncHttpClient.java#L71

the above code was calling SpanBuilder asChildOf(Span parent), which in fact is only a convenience method that ends up just doing: addReference(References.CHILD_OF, parent.context())... so we should make it more flexible for our clients to just provide the SpanContext and not the span.

https://github.com/opentracing/opentracing-java/blob/master/opentracing-api/src/main/java/io/opentracing/Tracer.java#L119-L125

Please see the README for additional context : https://github.com/opentracing-contrib/java-vertx-web
| SpanContext serverContext = TracingFilter.serverSpanContext(routingContext);

I also removed the "// TODO: REMOVE" noise of  System.out.println("ACTIVE_SPAN......